### PR TITLE
0.2.1.1: Fix the printing when a moderator affects a path more than once

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: power4mome
 Title: Power Analysis for Moderation and Mediation
-Version: 0.2.1
+Version: 0.2.1.1
 Authors@R:
     c(person(given = "Shu Fai",
            family = "Cheung",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# power4mome 0.2.1.1
+
+## Bug Fixes
+
+- Fixed the printing of the conditional
+  effects in the simulated data. If a
+  moderator affects more than only
+  component paths (e.g., both the a-path
+  and a b-path in a simple mediation
+  model), it will be counted only once
+  in the printing. This affects only the
+  printout used to examine the generated
+  data, and has not impact on the generated
+  data.
+  (0.2.1.1)
+
 # power4mome 0.2.1
 
 ## New Features

--- a/R/sim_data_helpers.R
+++ b/R/sim_data_helpers.R
@@ -736,6 +736,7 @@ get_w <- function(
             }
           })
   out <- unlist(out)
+  out <- unique(out)
   out <- out[!is.na(out)]
   out
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![R-CMD-check](https://github.com/sfcheung/power4mome/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/sfcheung/power4mome/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-(Version 0.2.1, updated on 2026-03-23, [release history](https://sfcheung.github.io/power4mome/news/index.html))
+(Version 0.2.1.1, updated on 2026-04-12, [release history](https://sfcheung.github.io/power4mome/news/index.html))
 
 # power4mome <a href="https://sfcheung.github.io/power4mome/"><img src="man/figures/logo.png" align="right" height="120" alt="power4mome website" /></a>
 

--- a/tests/testthat/test-power4test_print_dual_stage.R
+++ b/tests/testthat/test-power4test_print_dual_stage.R
@@ -1,0 +1,38 @@
+skip("WIP")
+
+test_that("w on more than one component paths", {
+
+model <-
+"
+m ~ x + w + x:w
+y ~ m + w + m:w + x
+"
+model_es <-
+"
+m ~ x: s
+m ~ x:w: m
+y ~ w: s
+y ~ m:w: l
+y ~ m: m
+y ~ x: s
+"
+
+# Test the Model Specification
+
+out <- power4test(
+  nrep = 2,
+  model = model,
+  pop_es = model_es,
+  n = 100,
+  fit_model_args = list(fit_function = "lm"),
+  iseed = 1234,
+  progress = !is_testing()
+)
+
+tmp <- capture.output(print(out))
+
+expect_all_false(grepl("Conditional on moderator(s): w, w", tmp))
+
+expect_true(any(grepl("[w] (w)", tmp, fixed = TRUE)))
+
+})


### PR DESCRIPTION
tests and checks passed.